### PR TITLE
fix: add missing `<time>` tags

### DIFF
--- a/src/characters/poly.vto
+++ b/src/characters/poly.vto
@@ -59,7 +59,7 @@ artworks:
             <div class="grid grid-cols-2 mb-2">
               <div><strong>Gender:</strong></div><div>Female</div>
               <div><strong>Age:</strong></div><div>28</div>
-              <div><strong>Birthday:</strong></div><div>14.07.</div>
+              <div><strong>Birthday:</strong></div><time datetime="07-14">14.07.</time>
               <div><strong>Personality:</strong></div><div>Kind / Motivating</div>
               <div><strong>Favorite Song:</strong></div><div><a href="https://www.youtube.com/watch?v=rrazgiHexZY" target="_blank">Sota Fujimori - Polygon</a></div>
             </div>
@@ -70,7 +70,7 @@ artworks:
             <div class="grid grid-cols-2">
               <div><strong>Character Design:</strong></div><div><a href="/">pixeldesu</a></div>
               <div><strong>Initial Illustration:</strong></div><div><a href="https://meriucchi.carrd.co/" target="_blank">Meriucchi</a></div>
-              <div><strong>Date of Appearance:</strong></div><div>14.07.2014</div>
+              <div><strong>Date of Appearance:</strong></div><time datetime="2014-07-14">14.07.2014</time>
             </div>
           {{ /comp }}
           {{ comp ui.raisedCard { classes: "prose mb-3" } }}

--- a/src/events.vto
+++ b/src/events.vto
@@ -16,7 +16,7 @@ title: Events
   {{ comp ui.raisedCard { classes: "mb-3 prose" } }}
     <h2 class="mb-0">{{ event.name }}</h2>
     <p class="text-sm mb-2">
-      From {{ event.date.start |> date('HUMAN_DATE') }} to {{ event.date.end |> date('HUMAN_DATE') }} in {{ event.location.name }}
+      From <time datetime={{ event.date.start |> date }}>{{ event.date.start |> date('HUMAN_DATE') }}</time> to <time datetime={{ event.date.end |> date }}>{{ event.date.end |> date('HUMAN_DATE') }}</time> in {{ event.location.name }}
     </p>
     <div class="flex items-center mt-3">
       <ul class="p-0 m-0">


### PR DESCRIPTION
while reading the blog i've noticed while the blog is mostly using `<time>` tag, [character](https://pixelde.su/characters/poly/) and [events](https://pixelde.su/events/) section missed time tags.

| characters | events |
| - | - |
|  ![image](https://github.com/user-attachments/assets/d32a0051-dd25-45ee-80c0-89ce1c28e89f) | ![image](https://github.com/user-attachments/assets/5223fa2a-45dc-409a-859f-1de3331b809b) |
